### PR TITLE
fix: add workflow path to push trigger for main branch

### DIFF
--- a/.github/workflows/backstage-ci-cd.yml
+++ b/.github/workflows/backstage-ci-cd.yml
@@ -13,6 +13,7 @@ on:
     branches: [main]
     paths:
       - 'asela-apps/**'
+      - '.github/workflows/**'
 
 env:
   NODE_VERSION: '20'


### PR DESCRIPTION
## Problem
The CI/CD workflow didn't run after merging PR #3 because the push trigger for main branch only watches `asela-apps/**` but not `.github/workflows/**`. When only the workflow file changes, it doesn't trigger.

## Solution
Add `.github/workflows/**` to the push trigger paths so the workflow runs when:
- Application code changes (`asela-apps/**`)
- Workflow files change (`.github/workflows/**`)

This ensures the CI/CD pipeline runs when the workflow itself is updated.