### PR TITLE
debug: extensive logging to troubleshoot Trivy scan issue

### DIFF
--- a/.github/workflows/backstage-ci-cd.yml
+++ b/.github/workflows/backstage-ci-cd.yml
@@ -162,11 +162,55 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # DEBUG: Test scan-image logic in PRs
+  debug-scan-image:
+    name: Debug Scan Image Logic
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Simulate ECR login output
+        id: simulate-ecr
+        run: |
+          # Simulate what ECR login would output
+          MOCK_REGISTRY="123456789012.dkr.ecr.us-east-1.amazonaws.com"
+          echo "registry=$MOCK_REGISTRY" >> $GITHUB_OUTPUT
+          echo "Simulated registry: $MOCK_REGISTRY"
+          
+      - name: Test image URI construction
+        id: test-uri
+        run: |
+          # Test the exact same logic as build-push job
+          REGISTRY="${{ steps.simulate-ecr.outputs.registry }}"
+          REPOSITORY="backstage"
+          IMAGE_URI="$REGISTRY/$REPOSITORY:latest"
+          
+          echo "=== Testing URI Construction ==="
+          echo "Registry: '$REGISTRY'"
+          echo "Repository: '$REPOSITORY'"
+          echo "Constructed URI: '$IMAGE_URI'"
+          echo "URI length: ${#IMAGE_URI}"
+          
+          # Output for use in next step
+          echo "test-image-uri=$IMAGE_URI" >> $GITHUB_OUTPUT
+          
+          # Validate format
+          if [[ "$IMAGE_URI" =~ ^[a-zA-Z0-9.-]+\.amazonaws\.com/[a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+$ ]]; then
+            echo "✅ Image URI format is valid"
+          else
+            echo "❌ Image URI format is invalid!"
+            exit 1
+          fi
+          
+      - name: Test Trivy with mock image
+        run: |
+          echo "Would run Trivy with: ${{ steps.test-uri.outputs.test-image-uri }}"
+          # Note: We can't actually run Trivy without a real image
+          
   # PR Gate - All checks must pass
   pr-gate:
     name: PR Gate
     if: github.event_name == 'pull_request'
-    needs: [code-quality, test, security, docker-pr]
+    needs: [code-quality, test, security, docker-pr, debug-scan-image]
     runs-on: ubuntu-latest
     steps:
       - name: PR Gate Status
@@ -178,6 +222,7 @@ jobs:
           echo "- Tests: ${{ needs.test.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Security: ${{ needs.security.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Docker Build: ${{ needs.docker-pr.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Debug Scan: ${{ needs.debug-scan-image.result }}" >> $GITHUB_STEP_SUMMARY
 
   # ============================================
   # MAIN WORKFLOW - Runs on push to main
@@ -189,7 +234,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
-      image-uri: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+      image-uri: ${{ steps.debug-output.outputs.final-image-uri }}
       image-digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
@@ -205,6 +250,14 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
       
+      - name: Debug - Check ECR login output
+        run: |
+          echo "=== Debug ECR Login Output ==="
+          echo "Registry: '${{ steps.login-ecr.outputs.registry }}'"
+          echo "Registry length: ${#REGISTRY}"
+          REGISTRY="${{ steps.login-ecr.outputs.registry }}"
+          echo "Stored REGISTRY: '$REGISTRY'"
+          
       - uses: docker/setup-buildx-action@v3
       
       - name: Generate metadata
@@ -251,14 +304,54 @@ jobs:
         with:
           name: deployment-manifest
           path: deployment-manifest.json
+          
+      - name: Debug - Set final outputs
+        id: debug-output
+        run: |
+          echo "=== Setting Final Outputs ==="
+          FINAL_URI="${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest"
+          echo "Registry from ECR login: '${{ steps.login-ecr.outputs.registry }}'"
+          echo "Repository: '${{ env.ECR_REPOSITORY }}'"
+          echo "Final URI: '$FINAL_URI'"
+          echo "Final URI length: ${#FINAL_URI}"
+          
+          # Set output
+          echo "final-image-uri=$FINAL_URI" >> $GITHUB_OUTPUT
+          
+          # Also log to summary
+          echo "### Build Push Debug Output" >> $GITHUB_STEP_SUMMARY
+          echo "- Registry: \`${{ steps.login-ecr.outputs.registry }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Repository: \`${{ env.ECR_REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Final Image URI: \`$FINAL_URI\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Digest: \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
 
-  # Security scan on pushed image
+  # Security scan on pushed image (DEBUG VERSION)
   scan-image:
     name: Scan ECR Image
     needs: build-push
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
+      - name: Debug - Check build-push outputs
+        run: |
+          echo "## Debug Information" >> $GITHUB_STEP_SUMMARY
+          echo "### Build Push Outputs:" >> $GITHUB_STEP_SUMMARY
+          echo "- image-uri: '${{ needs.build-push.outputs.image-uri }}'" >> $GITHUB_STEP_SUMMARY
+          echo "- image-digest: '${{ needs.build-push.outputs.image-digest }}'" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          echo "=== Debugging build-push outputs ==="
+          echo "image-uri value: '${{ needs.build-push.outputs.image-uri }}'"
+          echo "image-digest value: '${{ needs.build-push.outputs.image-digest }}'"
+          echo "Length of image-uri: ${#IMAGE_URI}"
+          IMAGE_URI="${{ needs.build-push.outputs.image-uri }}"
+          echo "Stored IMAGE_URI: '$IMAGE_URI'"
+          
+          if [ -z "${{ needs.build-push.outputs.image-uri }}" ]; then
+            echo "ERROR: image-uri is empty!"
+            exit 1
+          fi
+          
       - name: Run Trivy on ECR image
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
## Debug PR for Trivy Scan Issue

This PR adds extensive debug logging to help identify why Trivy is receiving a dot (`.`) instead of a proper image reference.

### Debug Features Added:

1. **ECR Login Debug** - Logs the registry output from ECR login
2. **Build Output Debug** - Explicit step to set and log the final image URI
3. **Pre-Scan Debug** - Logs all outputs before Trivy runs
4. **PR Test Job** - Tests URI construction logic in PRs

### What to Look For:

1. In the PR checks, look at the "Debug Scan Image Logic" job output
2. After merging, check:
   - "Debug - Check ECR login output" step in build-push job
   - "Debug - Set final outputs" step at the end of build-push job
   - "Debug - Check build-push outputs" step in scan-image job

The debug output will show exactly what value is being passed to Trivy and help us identify where the empty/dot value is coming from.

### Next Steps:

1. Review the PR test output
2. If PR tests look good, merge to see the full debug output
3. Fix the root cause based on debug findings
4. Remove debug code in a follow-up PR