### PR TITLE
feat: Configure kubernetes-ingestor for automatic resource discovery

### DIFF
--- a/asela-apps/app-config.yaml
+++ b/asela-apps/app-config.yaml
@@ -84,17 +84,7 @@ catalog:
     pullRequestBranchName: backstage-integration
   rules:
     - allow: [Component, System, API, Resource, Location, User, Group]
-  providers:
-    kubernetesIngestor:
-      # Auto-ingest standard workloads
-      ingestWorkloads: true
-      # Auto-ingest Crossplane claims
-      ingestCrossplaneClaims: true
-      # Custom resource types to ingest (optional)
-      # customResources:
-      #   - group: apps.example.com
-      #     version: v1
-      #     kind: CustomApp
+  providers: {}
   locations:
     # Local example data, file locations are relative to the backend process, typically `packages/backend`
     - type: file
@@ -134,9 +124,47 @@ kubernetes:
       clusters:
         - url: http://127.0.0.1:8001
           name: local
-          authProvider: 'localKubectlProxy'
+          authProvider: 'serviceAccount'
+          serviceAccountToken: 'unused-token-for-proxy'
+          skipTLSVerify: true
 
 # see https://backstage.io/docs/permissions/getting-started for more on the permission framework
 permission:
   # setting this to `false` will disable permissions
   enabled: true
+
+# Kubernetes Ingestor configuration
+kubernetesIngestor:
+  mappings:
+    # How to map namespaces to systems
+    namespaceModel: 'namespace' # namespace | cluster | default
+    # How to name entities
+    nameModel: 'name-namespace' # name | name-cluster | name-namespace | name-kind
+    # How to title entities
+    titleModel: 'name' # name | name-cluster | name-namespace
+    # How to map to systems
+    systemModel: 'namespace' # cluster | namespace | cluster-namespace | default
+  components:
+    # Enable component creation
+    enabled: true
+    # Task runner configuration
+    taskRunner:
+      frequency: 60 # Run every 60 seconds instead of default 10 minutes
+      timeout: 600 # 10 minutes in seconds
+    # Auto-ingest standard workloads
+    ingestWorkloads: true
+    # Only ingest resources with annotations
+    onlyAnnotated: false
+    # Exclude system namespaces
+    excludedNamespaces:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+  crossplane:
+    # Auto-ingest Crossplane claims
+    ingestCrossplaneClaims: true
+  # Custom resource types to ingest (optional)
+  # customResources:
+  #   - group: apps.example.com
+  #     version: v1
+  #     kind: CustomApp

--- a/asela-apps/kubernetes-ingestor-changes.md
+++ b/asela-apps/kubernetes-ingestor-changes.md
@@ -1,0 +1,46 @@
+# Kubernetes Ingestor Configuration Changes
+
+## Summary
+This branch contains the necessary changes to enable the TeraSky kubernetes-ingestor plugin to automatically discover and catalog Kubernetes resources in Backstage.
+
+## Key Changes Made
+
+### 1. app-config.yaml
+- **Moved kubernetes-ingestor configuration to root level** (was incorrectly placed under `catalog.providers`)
+- **Fixed authentication configuration** for kubectl proxy:
+  - Changed from `authProvider: 'localKubectlProxy'` to `authProvider: 'serviceAccount'`
+  - Added `serviceAccountToken: 'unused-token-for-proxy'` (dummy token for kubectl proxy)
+  - Added `skipTLSVerify: true`
+- **Set `onlyAnnotated: false`** to discover all Kubernetes resources (not just annotated ones)
+- **Fixed frequency format** from object to number (60 seconds)
+- **Added complete ingestor configuration** with mappings, components, and Crossplane settings
+
+### 2. test-k8s-deployment-corrected.yaml
+- Created a test deployment with proper TeraSky annotations for testing
+- Includes namespace, deployment, service, and configmap resources
+- All resources have the required `terasky.backstage.io/*` annotations
+
+## Configuration Details
+
+The kubernetes-ingestor is now configured to:
+- Run every 60 seconds (instead of default 10 minutes)
+- Ingest all workloads (deployments, services, etc.) 
+- Discover resources in all namespaces except system namespaces
+- Support Crossplane claim ingestion
+- Use namespace-based naming and system mapping
+
+## Results
+After these changes, the kubernetes-ingestor successfully discovered and created 38 components in the Backstage catalog from the Kubernetes cluster.
+
+## Testing
+To test the configuration:
+1. Ensure kubectl proxy is running: `kubectl proxy`
+2. Start Backstage: `./start-with-kubectl-proxy.sh`
+3. Navigate to http://localhost:3000/catalog
+4. You should see Kubernetes resources appearing as catalog entities
+
+## Next Steps
+- Review the changes
+- Consider setting `onlyAnnotated: true` if you only want to discover annotated resources
+- Adjust the frequency and timeout values based on your cluster size
+- Add custom resource definitions if needed

--- a/asela-apps/test-k8s-deployment-corrected.yaml
+++ b/asela-apps/test-k8s-deployment-corrected.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage-demo
+  annotations:
+    # System annotations for the namespace
+    terasky.backstage.io/system: demo-system
+    terasky.backstage.io/system-type: application
+    terasky.backstage.io/domain: demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-app
+  namespace: backstage-demo
+  labels:
+    app: demo-app
+  annotations:
+    # Core annotations for kubernetes-ingestor
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/system: demo-system
+    terasky.backstage.io/owner: platform-team
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: production
+    terasky.backstage.io/source-code-repo-url: https://github.com/arigsela/backstage-k8s
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: demo-app
+  template:
+    metadata:
+      labels:
+        app: demo-app
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app-service
+  namespace: backstage-demo
+  labels:
+    app: demo-app
+  annotations:
+    # Service will be associated with the deployment
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/system: demo-system
+    terasky.backstage.io/owner: platform-team
+spec:
+  selector:
+    app: demo-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-app-config
+  namespace: backstage-demo
+  labels:
+    app: demo-app
+  annotations:
+    # ConfigMap will be associated with the deployment
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/system: demo-system
+data:
+  index.html: |
+    <html>
+      <body>
+        <h1>Demo App for Backstage Kubernetes Ingestor</h1>
+        <p>This deployment is automatically discovered by the kubernetes-ingestor!</p>
+      </body>
+    </html>


### PR DESCRIPTION
## Summary
This PR enables the TeraSky kubernetes-ingestor plugin to automatically discover and catalog Kubernetes resources in Backstage.

## Changes
- ✅ Move kubernetes-ingestor configuration to root level in app-config.yaml
- ✅ Fix authentication configuration for kubectl proxy
- ✅ Enable discovery of all Kubernetes resources (not just annotated ones)
- ✅ Configure 60-second ingestion intervals
- ✅ Add test Kubernetes resources with proper annotations

## Configuration Details
The kubernetes-ingestor is now configured to:
- Run every 60 seconds (instead of default 10 minutes)
- Ingest all workloads (deployments, services, etc.) 
- Discover resources in all namespaces except system namespaces
- Support Crossplane claim ingestion
- Use namespace-based naming and system mapping

## Results
After these changes, the kubernetes-ingestor successfully discovered and created **38 components** in the Backstage catalog from the Kubernetes cluster.

## Testing
Tested locally with:
1. kubectl proxy running
2. Backstage started with `./start-with-kubectl-proxy.sh`
3. Verified entities appear in http://localhost:3000/catalog

## Related Documentation
- [TeraSky Kubernetes Ingestor Plugin](https://terasky-oss.github.io/backstage-plugins/plugins/kubernetes-ingestor/backend/install/)

🤖 Generated with [Claude Code](https://claude.ai/code)