### PR TITLE
fix: configure kubernetes-ingestor to only discover annotated resources

### DIFF
--- a/asela-apps/app-config.yaml
+++ b/asela-apps/app-config.yaml
@@ -143,7 +143,7 @@ kubernetesIngestor:
     # How to title entities
     titleModel: 'name' # name | name-cluster | name-namespace
     # How to map to systems
-    systemModel: 'namespace' # cluster | namespace | cluster-namespace | default
+    systemModel: 'default' # cluster | namespace | cluster-namespace | default
   components:
     # Enable component creation
     enabled: true
@@ -154,7 +154,9 @@ kubernetesIngestor:
     # Auto-ingest standard workloads
     ingestWorkloads: true
     # Only ingest resources with annotations
-    onlyAnnotated: false
+    onlyAnnotated: true
+    # This is the actual config setting the plugin uses
+    onlyIngestAnnotatedResources: true
     # Exclude system namespaces
     excludedNamespaces:
       - kube-system


### PR DESCRIPTION
## Summary
- Configured kubernetes-ingestor to only discover resources with explicit annotations
- Set `onlyIngestAnnotatedResources: true` to filter out unannotated K8s resources
- Changed `systemModel` to 'default' for annotation-based system mapping

## Why this change?
Previously, the kubernetes-ingestor was discovering ALL Kubernetes resources in the cluster, which flooded the Backstage catalog with unnecessary entries. With this change, only resources that have the `terasky.backstage.io/add-to-catalog: "true"` annotation will be discovered and added to the catalog.

## Configuration changes
```yaml
kubernetesIngestor:
  components:
    # Only ingest resources with annotations
    onlyAnnotated: true
    # This is the actual config setting the plugin uses
    onlyIngestAnnotatedResources: true
```

## Impact
- ✅ Catalog will only show explicitly marked Kubernetes resources
- ✅ Cleaner and more manageable catalog
- ✅ Better control over what resources appear in Backstage
- ✅ Resources must have `terasky.backstage.io/add-to-catalog: "true"` annotation to be discovered

## Test plan
- [x] Updated configuration in app-config.yaml
- [ ] Restart Backstage and verify only annotated resources appear
- [ ] Confirm demo-app resources (with annotations) are visible
- [ ] Confirm other K8s resources (without annotations) are not visible

🤖 Generated with [Claude Code](https://claude.ai/code)